### PR TITLE
Fix goreleaser docker build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,6 +4,7 @@ builds:
   main: .
   env:
   - GO_PKG=github.com/exoscale/cert-manager-webhook-exoscale
+  - CGO_ENABLED=0
   flags:
   - -trimpath
   ldflags:


### PR DESCRIPTION
Statically compiles binary using goreleaser allowing it to work in alpine (musl based) docker image.