### PR TITLE
Add YAML for kubectl/kustomize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,9 @@ GOARCH ?= $(shell $(GO) env GOARCH)
 
 IMAGE_NAME := "exoscale/cert-manager-webhook-exoscale"
 
-OUT := $(shell pwd)/_out
+OUT := ${PWD}/_out
+
+DEPLOY_DIR := $(PWD)/deploy/exoscale-webhook
 
 KUBE_VERSION=1.27.1
 
@@ -43,7 +45,8 @@ docker-build:
 .PHONY: rendered-manifest.yaml
 rendered-manifest.yaml:
 	helm template \
-	    --name exoscale-webhook \
+	    exoscale-webhook \
         --set image.repository=$(IMAGE_NAME) \
-        --set image.tag=$(IMAGE_TAG) \
-        deploy/exoscale-webhook > "$(OUT)/rendered-manifest.yaml"
+        --set image.tag=$(VERSION) \
+        ${DEPLOY_DIR} > "$(OUT)/rendered-manifest.yaml"
+	cp "${OUT}/rendered-manifest.yaml" "${DEPLOY_DIR}-kustomize/deploy.yaml"

--- a/Makefile
+++ b/Makefile
@@ -48,5 +48,6 @@ rendered-manifest.yaml:
 	    exoscale-webhook \
         --set image.repository=$(IMAGE_NAME) \
         --set image.tag=$(VERSION) \
+        --namespace cert-manager \
         ${DEPLOY_DIR} > "$(OUT)/rendered-manifest.yaml"
 	cp "${OUT}/rendered-manifest.yaml" "${DEPLOY_DIR}-kustomize/deploy.yaml"

--- a/README.md
+++ b/README.md
@@ -17,12 +17,34 @@ Based on [Example Webhook](https://github.com/cert-manager/webhook-example).
 
 ### Installing
 
+#### With Helm
+
 Once everything is set up, install Exoscale Webhook:
 ```bash
 git clone https://github.com/exoscale/cert-manager-webhook-exoscale.git
 cd cert-manager-webhook-exoscale
 helm install exoscale-webhook ./deploy/exoscale-webhook
 ```
+
+#### With Kubectl or Kustomize
+
+The manifest is generated from Helm (`make rendered-manifest.yaml`)
+
+**Kubectl**
+```bash
+kubectl apply -f https://raw.githubusercontent.com/exoscale/cert-manager-webhook-exoscale/master/deploy/exoscale-webhook-kustomize/deploy.yaml
+```
+
+**Kustomization file**
+```yaml
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/exoscale.cert-manager-webhook-exoscale/deploy/exoscale-webhook-kustomize
+```
+
 
 ### How to use it
 

--- a/deploy/exoscale-webhook-kustomize/deploy.yaml
+++ b/deploy/exoscale-webhook-kustomize/deploy.yaml
@@ -1,0 +1,316 @@
+---
+# Source: exoscale-webhook/templates/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-manager-webhook-exoscale
+  labels:
+    app: exoscale-webhook
+    chart: exoscale-webhook-0.1.0
+    release: exoscale-webhook
+    heritage: Helm
+---
+# Source: exoscale-webhook/templates/rbac.yaml
+# Grant cert-manager permission to validate using our apiserver
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-webhook-exoscale:domain-solver
+  labels:
+    app: exoscale-webhook
+    chart: exoscale-webhook-0.1.0
+    release: exoscale-webhook
+    heritage: Helm
+rules:
+  - apiGroups:
+      - acme.exoscale.com
+    resources:
+      - '*'
+    verbs:
+      - 'create'
+---
+# Source: exoscale-webhook/templates/rbac.yaml
+# apiserver gets the auth-delegator role to delegate auth decisions to
+# the core apiserver
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-webhook-exoscale:auth-delegator
+  labels:
+    app: exoscale-webhook
+    chart: exoscale-webhook-0.1.0
+    release: exoscale-webhook
+    heritage: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: cert-manager-webhook-exoscale
+    namespace: default
+---
+# Source: exoscale-webhook/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-webhook-exoscale:domain-solver
+  labels:
+    app: exoscale-webhook
+    chart: exoscale-webhook-0.1.0
+    release: exoscale-webhook
+    heritage: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-webhook-exoscale:domain-solver
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: cert-manager
+    namespace: cert-manager
+---
+# Source: exoscale-webhook/templates/rbac.yaml
+# Grant the webhook permission to read the secrets containing the credentials
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cert-manager-webhook-exoscale:secrets-reader
+  namespace: default
+  labels:
+    app: exoscale-webhook
+    chart: exoscale-webhook-0.1.0
+    release: exoscale-webhook
+    heritage: Helm
+rules:
+  - apiGroups:
+    - ''
+    resources:
+    - 'secrets'
+    verbs:
+    - 'get'
+---
+# Source: exoscale-webhook/templates/rbac.yaml
+# Grant the webhook permission to read the ConfigMap containing the Kubernetes
+# apiserver's requestheader-ca-certificate.
+# This ConfigMap is automatically created by the Kubernetes apiserver.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cert-manager-webhook-exoscale:webhook-authentication-reader
+  namespace: kube-system
+  labels:
+    app: exoscale-webhook
+    chart: exoscale-webhook-0.1.0
+    release: exoscale-webhook
+    heritage: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: cert-manager-webhook-exoscale
+    namespace: default
+---
+# Source: exoscale-webhook/templates/rbac.yaml
+# Grant the webhook permission to read the secrets containing the credentials
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cert-manager-webhook-exoscale:secrets-reader
+  namespace: default
+  labels:
+    app: exoscale-webhook
+    chart: exoscale-webhook-0.1.0
+    release: exoscale-webhook
+    heritage: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager-webhook-exoscale:secrets-reader
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: cert-manager-webhook-exoscale
+    namespace: default
+---
+# Source: exoscale-webhook/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: cert-manager-webhook-exoscale
+  labels:
+    app: exoscale-webhook
+    chart: exoscale-webhook-0.1.0
+    release: exoscale-webhook
+    heritage: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      targetPort: https
+      protocol: TCP
+      name: https
+  selector:
+    app: exoscale-webhook
+    release: exoscale-webhook
+---
+# Source: exoscale-webhook/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cert-manager-webhook-exoscale
+  labels:
+    app: exoscale-webhook
+    chart: exoscale-webhook-0.1.0
+    release: exoscale-webhook
+    heritage: Helm
+spec:
+  replicas: 
+  selector:
+    matchLabels:
+      app: exoscale-webhook
+      release: exoscale-webhook
+  template:
+    metadata:
+      labels:
+        app: exoscale-webhook
+        release: exoscale-webhook
+    spec:
+      serviceAccountName: cert-manager-webhook-exoscale
+      containers:
+        - name: exoscale-webhook
+          image: "exoscale/cert-manager-webhook-exoscale:0.1.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --tls-cert-file=/tls/tls.crt
+            - --tls-private-key-file=/tls/tls.key
+          env:
+            - name: GROUP_NAME
+              value: "acme.exoscale.com"
+            - name: EXOSCALE_DEBUG
+              value: ""
+            - name: EXOSCALE_API_TRACE
+              value: ""
+          ports:
+            - name: https
+              containerPort: 443
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /healthz
+              port: https
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /healthz
+              port: https
+          volumeMounts:
+            - name: certs
+              mountPath: /tls
+              readOnly: true
+          resources:
+            {}
+      volumes:
+        - name: certs
+          secret:
+            secretName: cert-manager-webhook-exoscale-webhook-tls
+---
+# Source: exoscale-webhook/templates/apiservice.yaml
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.acme.exoscale.com
+  labels:
+    app: exoscale-webhook
+    chart: exoscale-webhook-0.1.0
+    release: exoscale-webhook
+    heritage: Helm
+  annotations:
+    cert-manager.io/inject-ca-from: "default/cert-manager-webhook-exoscale-webhook-tls"
+spec:
+  group: acme.exoscale.com
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: cert-manager-webhook-exoscale
+    namespace: default
+  version: v1alpha1
+---
+# Source: exoscale-webhook/templates/pki.yaml
+# Generate a CA Certificate used to sign certificates for the webhook
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cert-manager-webhook-exoscale-ca
+  namespace: "default"
+  labels:
+    app: exoscale-webhook
+    chart: exoscale-webhook-0.1.0
+    release: exoscale-webhook
+    heritage: Helm
+spec:
+  secretName: cert-manager-webhook-exoscale-ca
+  duration: 43800h # 5y
+  issuerRef:
+    name: cert-manager-webhook-exoscale-selfsign
+  commonName: "ca.exoscale-webhook.cert-manager"
+  isCA: true
+---
+# Source: exoscale-webhook/templates/pki.yaml
+# Finally, generate a serving certificate for the webhook to use
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cert-manager-webhook-exoscale-webhook-tls
+  namespace: "default"
+  labels:
+    app: exoscale-webhook
+    chart: exoscale-webhook-0.1.0
+    release: exoscale-webhook
+    heritage: Helm
+spec:
+  secretName: cert-manager-webhook-exoscale-webhook-tls
+  duration: 8760h # 1y
+  issuerRef:
+    name: cert-manager-webhook-exoscale-ca
+  dnsNames:
+  - cert-manager-webhook-exoscale
+  - cert-manager-webhook-exoscale.default
+  - cert-manager-webhook-exoscale.default.svc
+---
+# Source: exoscale-webhook/templates/pki.yaml
+# Create a selfsigned Issuer, in order to create a root CA certificate for
+# signing webhook serving certificates
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: cert-manager-webhook-exoscale-selfsign
+  namespace: "default"
+  labels:
+    app: exoscale-webhook
+    chart: exoscale-webhook-0.1.0
+    release: exoscale-webhook
+    heritage: Helm
+spec:
+  selfSigned: {}
+---
+# Source: exoscale-webhook/templates/pki.yaml
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: cert-manager-webhook-exoscale-ca
+  namespace: "default"
+  labels:
+    app: exoscale-webhook
+    chart: exoscale-webhook-0.1.0
+    release: exoscale-webhook
+    heritage: Helm
+spec:
+  ca:
+    secretName: cert-manager-webhook-exoscale-ca

--- a/deploy/exoscale-webhook-kustomize/deploy.yaml
+++ b/deploy/exoscale-webhook-kustomize/deploy.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cert-manager-webhook-exoscale
+  namespace: "cert-manager"
   labels:
     app: exoscale-webhook
     chart: exoscale-webhook-0.1.0
@@ -49,7 +50,7 @@ subjects:
   - apiGroup: ""
     kind: ServiceAccount
     name: cert-manager-webhook-exoscale
-    namespace: default
+    namespace: cert-manager
 ---
 # Source: exoscale-webhook/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -77,7 +78,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cert-manager-webhook-exoscale:secrets-reader
-  namespace: default
+  namespace: cert-manager
   labels:
     app: exoscale-webhook
     chart: exoscale-webhook-0.1.0
@@ -113,7 +114,7 @@ subjects:
   - apiGroup: ""
     kind: ServiceAccount
     name: cert-manager-webhook-exoscale
-    namespace: default
+    namespace: cert-manager
 ---
 # Source: exoscale-webhook/templates/rbac.yaml
 # Grant the webhook permission to read the secrets containing the credentials
@@ -121,7 +122,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cert-manager-webhook-exoscale:secrets-reader
-  namespace: default
+  namespace: cert-manager
   labels:
     app: exoscale-webhook
     chart: exoscale-webhook-0.1.0
@@ -135,13 +136,14 @@ subjects:
   - apiGroup: ""
     kind: ServiceAccount
     name: cert-manager-webhook-exoscale
-    namespace: default
+    namespace: cert-manager
 ---
 # Source: exoscale-webhook/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
   name: cert-manager-webhook-exoscale
+  namespace: "cert-manager"
   labels:
     app: exoscale-webhook
     chart: exoscale-webhook-0.1.0
@@ -163,6 +165,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cert-manager-webhook-exoscale
+  namespace: "cert-manager"
   labels:
     app: exoscale-webhook
     chart: exoscale-webhook-0.1.0
@@ -183,7 +186,7 @@ spec:
       serviceAccountName: cert-manager-webhook-exoscale
       containers:
         - name: exoscale-webhook
-          image: "exoscale/cert-manager-webhook-exoscale:0.1.0"
+          image: "exoscale/cert-manager-webhook-exoscale:dev"
           imagePullPolicy: IfNotPresent
           args:
             - --tls-cert-file=/tls/tls.crt
@@ -231,14 +234,14 @@ metadata:
     release: exoscale-webhook
     heritage: Helm
   annotations:
-    cert-manager.io/inject-ca-from: "default/cert-manager-webhook-exoscale-webhook-tls"
+    cert-manager.io/inject-ca-from: "cert-manager/cert-manager-webhook-exoscale-webhook-tls"
 spec:
   group: acme.exoscale.com
   groupPriorityMinimum: 1000
   versionPriority: 15
   service:
     name: cert-manager-webhook-exoscale
-    namespace: default
+    namespace: cert-manager
   version: v1alpha1
 ---
 # Source: exoscale-webhook/templates/pki.yaml
@@ -247,7 +250,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: cert-manager-webhook-exoscale-ca
-  namespace: "default"
+  namespace: "cert-manager"
   labels:
     app: exoscale-webhook
     chart: exoscale-webhook-0.1.0
@@ -267,7 +270,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: cert-manager-webhook-exoscale-webhook-tls
-  namespace: "default"
+  namespace: "cert-manager"
   labels:
     app: exoscale-webhook
     chart: exoscale-webhook-0.1.0
@@ -280,8 +283,8 @@ spec:
     name: cert-manager-webhook-exoscale-ca
   dnsNames:
   - cert-manager-webhook-exoscale
-  - cert-manager-webhook-exoscale.default
-  - cert-manager-webhook-exoscale.default.svc
+  - cert-manager-webhook-exoscale.cert-manager
+  - cert-manager-webhook-exoscale.cert-manager.svc
 ---
 # Source: exoscale-webhook/templates/pki.yaml
 # Create a selfsigned Issuer, in order to create a root CA certificate for
@@ -290,7 +293,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: cert-manager-webhook-exoscale-selfsign
-  namespace: "default"
+  namespace: "cert-manager"
   labels:
     app: exoscale-webhook
     chart: exoscale-webhook-0.1.0
@@ -305,7 +308,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: cert-manager-webhook-exoscale-ca
-  namespace: "default"
+  namespace: "cert-manager"
   labels:
     app: exoscale-webhook
     chart: exoscale-webhook-0.1.0

--- a/deploy/exoscale-webhook-kustomize/kustomization.yaml
+++ b/deploy/exoscale-webhook-kustomize/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deploy.yaml

--- a/deploy/exoscale-webhook/templates/deployment.yaml
+++ b/deploy/exoscale-webhook/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "exoscale-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ include "exoscale-webhook.name" . }}
     chart: {{ include "exoscale-webhook.chart" . }}

--- a/deploy/exoscale-webhook/templates/rbac.yaml
+++ b/deploy/exoscale-webhook/templates/rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "exoscale-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ include "exoscale-webhook.name" . }}
     chart: {{ include "exoscale-webhook.chart" . }}

--- a/deploy/exoscale-webhook/templates/service.yaml
+++ b/deploy/exoscale-webhook/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "exoscale-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ include "exoscale-webhook.name" . }}
     chart: {{ include "exoscale-webhook.chart" . }}


### PR DESCRIPTION
Provide YAML manifest to deploy without helm
```
$ make rendered-manifest.yaml
helm template \
    exoscale-webhook \
        --set image.repository="exoscale/cert-manager-webhook-exoscale" \
        --set image.tag=0.1.0 \
        cert-manager-webhook-exoscale/deploy/exoscale-webhook > "cert-manager-webhook-exoscale/_out/rendered-manifest.yaml"
cp "cert-manager-webhook-exoscale/_out/rendered-manifest.yaml" "cert-manager-webhook-exoscale/deploy/exoscale-webhook-kustomize/deploy.yaml"

```

Also update helm templates like https://github.com/cert-manager/webhook-example/pull/39