### PR TITLE
Allow to specify cert-manager namespace separately

### DIFF
--- a/deploy/exoscale-webhook/templates/rbac.yaml
+++ b/deploy/exoscale-webhook/templates/rbac.yaml
@@ -87,7 +87,7 @@ subjects:
   - apiGroup: ""
     kind: ServiceAccount
     name: {{ .Values.certManager.serviceAccountName }}
-    namespace: {{ .Values.certManager.namespace }}
+    namespace: {{or .Values.certManager.namespace .Release.Namespace }}
 ---
 # Grant the webhook permission to read the secrets containing the credentials
 apiVersion: rbac.authorization.k8s.io/v1
@@ -128,3 +128,42 @@ subjects:
     kind: ServiceAccount
     name: {{ include "exoscale-webhook.fullname" . }}
     namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "exoscale-webhook.fullname" . }}:flowcontrol-solver
+  labels:
+    app: {{ include "exoscale-webhook.name" . }}
+    chart: {{ include "exoscale-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups:
+      - "flowcontrol.apiserver.k8s.io"
+    resources:
+      - 'prioritylevelconfigurations'
+      - 'flowschemas'
+    verbs:
+      - 'list'
+      - 'watch'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "exoscale-webhook.fullname" . }}:flowcontrol-solver
+  labels:
+    app: {{ include "exoscale-webhook.name" . }}
+    chart: {{ include "exoscale-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "exoscale-webhook.fullname" . }}:flowcontrol-solver
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ include "exoscale-webhook.fullname" . }}
+    namespace: {{ .Release.Namespace | quote }}
+---

--- a/deploy/exoscale-webhook/values.yaml
+++ b/deploy/exoscale-webhook/values.yaml
@@ -1,7 +1,8 @@
 groupName: acme.exoscale.com
 
 certManager:
-  namespace: cert-manager
+  # Use this value to specify the namespace cert-manager is located in
+  # namespace: cert-manager
   serviceAccountName: cert-manager
 
 image:
@@ -25,8 +26,8 @@ service:
   type: ClusterIP
   port: 443
 
-
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
Solves https://github.com/exoscale/cert-manager-webhook-exoscale/issues

Because currently, cert-manager has to be located in a namespace called "cert-manager", webhook fails to work when located in a different namespace.