### PR TITLE
fix(deployment): Update the default webhook docker image to an existing image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,6 @@ rendered-manifest.yaml:
 	helm template \
 	    exoscale-webhook \
         --set image.repository=$(IMAGE_NAME) \
-        --set image.tag=$(VERSION) \
         --namespace cert-manager \
         ${DEPLOY_DIR} > "$(OUT)/rendered-manifest.yaml"
 	cp "${OUT}/rendered-manifest.yaml" "${DEPLOY_DIR}-kustomize/deploy.yaml"

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ rendered-manifest.yaml:
 	helm template \
 	    exoscale-webhook \
         --set image.repository=$(IMAGE_NAME) \
+        --set image.tag="latest" \
         --namespace cert-manager \
         ${DEPLOY_DIR} > "$(OUT)/rendered-manifest.yaml"
 	cp "${OUT}/rendered-manifest.yaml" "${DEPLOY_DIR}-kustomize/deploy.yaml"

--- a/deploy/exoscale-webhook-kustomize/deploy.yaml
+++ b/deploy/exoscale-webhook-kustomize/deploy.yaml
@@ -186,7 +186,7 @@ spec:
       serviceAccountName: cert-manager-webhook-exoscale
       containers:
         - name: exoscale-webhook
-          image: "exoscale/cert-manager-webhook-exoscale:dev"
+          image: "exoscale/cert-manager-webhook-exoscale:latest"
           imagePullPolicy: IfNotPresent
           args:
             - --tls-cert-file=/tls/tls.crt


### PR DESCRIPTION
# Description
Update the default image tag of the webhook docker image because the dev tag doesn't exist on dockerhub.
I know this can be customized in the `kuztomise.yaml` file, but I think it might be nice to be able to deploy it as it is. 

I chose the tag `latest` to have the same default value as the helm deployment.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Integration testing

## Testing

<!--
Describe the tests you did
-->
