### PR TITLE
feat(doc): Add the minimum requirements needed for the Exoscale Key in the documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## UNRELEASED
 
+- feat(doc): Add the minimum requirements needed for the Exoscale Key in the documentation
+(#11)
 - Add Action to do releases (#8)
 
 ## 0.2.0

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Here is an example of the minimal policy required for the IAM role:
           "action": "deny"
         },
         {
-          "expression": "operation in ['list-dns-domains', 'list-dns-domain-records', 'get-dns-domain-record', 'get-operation', 'create-dns-domain-record' and 'delete-dns-domain-record']",
+          "expression": "operation in ['list-dns-domains', 'list-dns-domain-records', 'get-dns-domain-record', 'get-operation', 'create-dns-domain-record', 'delete-dns-domain-record']",
           "action": "allow"
         }
       ]

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ metadata:
 type: Opaque
 ```
 
-The IAM role policy of your key should allow at least the following `operation`s for your domain: `list-dns-domains`, `list-dns-domain-records`, `get-dns-domain-record`, `get-operation`, `create-dns-domain-record` and `delete-dns-domain-record`
+The IAM role policy of your key should allow at least the following `operation`s for your domain: `list-dns-domains`, `list-dns-domain-records`, `get-dns-domain-record`, `create-dns-domain-record` and `delete-dns-domain-record`
 
 Here is an example of the minimal policy required for the IAM role:
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,31 @@ metadata:
 type: Opaque
 ```
 
+Your Exoscale Key should have at least the following `operation` for your domain: `list-dns-domain-records`, `get-dns-domain-record`, `list-dns-domains`, `update-dns-domain-record`, `create-dns-domain-record`, `delete-dns-domain-record`
+
+Here is an example of the minimum policy required for the Exoscale Key:
+
+```json
+{
+  "default-service-strategy": "deny",
+  "services": {
+    "dns": {
+      "type": "rules",
+      "rules": [
+        {
+          "expression": "resources.dns_domain.unicode_name!=\"example.com\"",
+          "action": "deny"
+        },
+        {
+          "expression": "operationin['list-dns-domain-records','get-dns-domain-record','list-dns-domains','update-dns-domain-record','create-dns-domain-record','delete-dns-domain-record']",
+          "action": "allow"
+        }
+      ]
+    }
+  }
+}
+```
+
 And run:
 ```bash
 kubectl create -f secret.yaml

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Here is an example of the minimal policy required for the IAM role:
           "action": "deny"
         },
         {
-          "expression": "operation in ['list-dns-domains', 'list-dns-domain-records', 'get-dns-domain-record', 'get-operation', 'create-dns-domain-record', 'delete-dns-domain-record']",
+          "expression": "operation in ['list-dns-domains', 'list-dns-domain-records', 'get-dns-domain-record', 'create-dns-domain-record', 'delete-dns-domain-record']",
           "action": "allow"
         }
       ]

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ spec:
   dnsNames:
   - example.com
   issuerRef:
-    name: exosacle-issuer
+    name: exoscale-issuer
   secretName: example-com-tls
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ Based on [Example Webhook](https://github.com/cert-manager/webhook-example).
 - [Helm](https://helm.sh/) [installed](https://helm.sh/docs/intro/install/)
 - [cert-manager](https://cert-manager.io/docs/installation/)
 
-> Note: if you want to restrict Exoscale API access key make sure the following operations are allowed: `list-dns-domains`, `list-dns-domain-records`, `get-dns-domain-record`, `get-operation`, `create-dns-domain-record` and `delete-dns-domain-record`.
-
 ### Installing
 
 #### With Helm
@@ -68,9 +66,9 @@ metadata:
 type: Opaque
 ```
 
-Your Exoscale Key should have at least the following `operation` for your domain: `list-dns-domain-records`, `get-dns-domain-record`, `list-dns-domains`, `update-dns-domain-record`, `create-dns-domain-record`, `delete-dns-domain-record`
+The IAM role policy of your key should allow at least the following `operation`s for your domain: `list-dns-domains`, `list-dns-domain-records`, `get-dns-domain-record`, `get-operation`, `create-dns-domain-record` and `delete-dns-domain-record`
 
-Here is an example of the minimum policy required for the Exoscale Key:
+Here is an example of the minimal policy required for the IAM role:
 
 ```json
 {
@@ -80,11 +78,11 @@ Here is an example of the minimum policy required for the Exoscale Key:
       "type": "rules",
       "rules": [
         {
-          "expression": "resources.dns_domain.unicode_name!=\"example.com\"",
+          "expression": "resources.dns_domain.unicode_name != \"example.com\"",
           "action": "deny"
         },
         {
-          "expression": "operationin['list-dns-domain-records','get-dns-domain-record','list-dns-domains','update-dns-domain-record','create-dns-domain-record','delete-dns-domain-record']",
+          "expression": "operation in ['list-dns-domains', 'list-dns-domain-records', 'get-dns-domain-record', 'get-operation', 'create-dns-domain-record' and 'delete-dns-domain-record']",
           "action": "allow"
         }
       ]

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ spec:
             apiKeyRef:
               key: EXOSCALE_API_KEY
               name: exoscale-secret
-            apiSecretRefRef:
+            apiSecretRef:
               key: EXOSCALE_API_SECRET
               name: exoscale-secret
 ```


### PR DESCRIPTION
# Description
Add the minimum required permission for the Exoscale Key. 
I think that might be useful to other people who don't want to set unnecessary permissions. 

Please don't hesitate to correct if some of the `operation` are not needed or some are missing. 
Please don't hesitate to modify the policy if you have a way to make it more secure.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Integration testing

## Testing

<!--
Describe the tests you did
-->

Tested the permissions with `lego`. They are enough to get a certificate. 
