### PR TITLE
fix(doc): update example IAM Role to be more restrictive 📝

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ Here is an example of the minimal policy required for the IAM role:
           "action": "deny"
         },
         {
+          "expression": "parameters.has('type') && parameters.type != 'TXT'",
+          "action": "deny"
+        },
+        {
+          "expression": "resources.has('dns_domain_record') && resources.dns_domain_record.has('type') && resources.dns_domain_record.type != 'TXT'",
+          "action": "deny"
+        },
+        {
           "expression": "operation in ['list-dns-domains', 'list-dns-domain-records', 'get-dns-domain-record', 'create-dns-domain-record', 'delete-dns-domain-record']",
           "action": "allow"
         }


### PR DESCRIPTION
# Description
Add a more restrictive IAM Role example to allow creation / deletion of `TXT` records only.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Integration testing

## Testing

Tested with `lego`, I am able to get a certificate. And some additional manual tests.

However, I didn't test it with the cert-manager: I wanted to have your review before deploying it on our cluster.
