### PR TITLE
Fix: TXT content must be unquoted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## UNRELEASED
 
+- bug: TXT content must be unquoted (#13)
 - feat(doc): Add the minimum requirements needed for the Exoscale Key in the documentation
 (#11)
 - Add Action to do releases (#8)


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->
Fix integration test (TXT record could never be found but failed to be created as it was present)
```
2023/12/07 12:32:46 [INFO] domain record "cert-manager-dns01-tests" not found, nothing to do
[controller-runtime] log.SetLogger(...) was never called, logs will not be displayed:
goroutine 124 [running]:
runtime/debug.Stack()
        /usr/lib/go/src/runtime/debug/stack.go:24 +0x5e
sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
        /home/jessica/git/exoscale/cert-manager-webhook-exoscale/vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go:59 +0xcd
sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).Enabled(0xc0005f8700, 0xc000303930?)
        /home/jessica/git/exoscale/cert-manager-webhook-exoscale/vendor/sigs.k8s.io/controller-runtime/pkg/log/deleg.go:111 +0x32
github.com/go-logr/logr.Logger.Enabled(...)
        /home/jessica/git/exoscale/cert-manager-webhook-exoscale/vendor/github.com/go-logr/logr/logr.go:261
github.com/go-logr/logr.Logger.Info({{0x24af408?, 0xc0005f8700?}, 0x0?}, {0x21a0c5c, 0x16}, {0x0, 0x0, 0x0})
        /home/jessica/git/exoscale/cert-manager-webhook-exoscale/vendor/github.com/go-logr/logr/logr.go:274 +0x72
sigs.k8s.io/controller-runtime/pkg/envtest.(*Environment).Start(0xc00014ec80)
        /home/jessica/git/exoscale/cert-manager-webhook-exoscale/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/server.go:260 +0x419
github.com/cert-manager/cert-manager/test/apiserver.RunBareControlPlane(0xc00051d520)
        /home/jessica/git/exoscale/cert-manager-webhook-exoscale/vendor/github.com/cert-manager/cert-manager/test/apiserver/apiserver.go:44 +0x2f
github.com/cert-manager/cert-manager/test/acme.(*fixture).setup(0xc00066eb40, 0xc00051d520)
        /home/jessica/git/exoscale/cert-manager-webhook-exoscale/vendor/github.com/cert-manager/cert-manager/test/acme/fixture.go:114 +0x105
github.com/cert-manager/cert-manager/test/acme.(*fixture).RunExtended(0xc00066eb40, 0xc00078ae80?)
        /home/jessica/git/exoscale/cert-manager-webhook-exoscale/vendor/github.com/cert-manager/cert-manager/test/acme/fixture.go:100 +0x2d
github.com/exoscale/cert-manager-webhook-exoscale.TestRunsSuite(0x0?)
        /home/jessica/git/exoscale/cert-manager-webhook-exoscale/main_test.go:29 +0x155
testing.tRunner(0xc00051d520, 0x229b698)
        /usr/lib/go/src/testing/testing.go:1595 +0xff
created by testing.(*T).Run in goroutine 1
        /usr/lib/go/src/testing/testing.go:1648 +0x3ad
=== RUN   TestRunsSuite/Extended
=== RUN   TestRunsSuite/Extended/DeletingOneRecordRetainsOthers
2023/12/07 12:32:50 [INFO] found client credentials in environment, ignoring config
    suite.go:81: expected Present to not error, but got: failed to create domain record: Post "https://api-ch-gva-2.exoscale.com/v2/dns-domain/89083a5c-b648-474a-0000-00000010c712/record": invalid request: Matching record already exists

```
## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Integration testing

## Testing

<!--
Describe the tests you did

-->

```
=== RUN   TestRunsSuite
=== RUN   TestRunsSuite/Basic
=== RUN   TestRunsSuite/Basic/PresentRecord
    suite.go:38: Calling Present with ChallengeRequest: &v1alpha1.ChallengeRequest{UID:"", Action:"", Type:"", DNSName:"example.com", Key:"123d==", ResourceNamespace:"basic-present-record", ResolvedFQDN:"cert-manager-dns01-tests.jessica.exoscale.me.", ResolvedZone:"jessica.exoscale.me.", AllowAmbientCredentials:false, Config:(*v1.JSON)(0xc00032a150)}
2023/12/07 13:44:09 [INFO] found client credentials in environment, ignoring config
2023/12/07 13:44:13 [INFO] found client credentials in environment, ignoring config
2023/12/07 13:44:17 [INFO] found client credentials in environment, ignoring config
2023/12/07 13:44:18 [INFO] domain record "cert-manager-dns01-tests" not found, nothing to do
=== RUN   TestRunsSuite/Extended
=== RUN   TestRunsSuite/Extended/DeletingOneRecordRetainsOthers
2023/12/07 13:44:23 [INFO] found client credentials in environment, ignoring config
2023/12/07 13:44:27 [INFO] found client credentials in environment, ignoring config
2023/12/07 13:44:55 [INFO] found client credentials in environment, ignoring config
2023/12/07 13:45:00 [INFO] found client credentials in environment, ignoring config
2023/12/07 13:45:00 [INFO] domain record "cert-manager-dns01-tests" not found, nothing to do
2023/12/07 13:45:00 [INFO] found client credentials in environment, ignoring config
--- PASS: TestRunsSuite (60.75s)
    --- PASS: TestRunsSuite/Basic (10.09s)
        --- PASS: TestRunsSuite/Basic/PresentRecord (10.09s)
    --- PASS: TestRunsSuite/Extended (42.90s)
        --- PASS: TestRunsSuite/Extended/DeletingOneRecordRetainsOthers (42.90s)
PASS
ok      github.com/exoscale/cert-manager-webhook-exoscale       60.779s
```