### PR TITLE
go.mk: remove submodule and initialize through make

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,5 +19,5 @@ jobs:
         go-version: '^1.18'
     - name: Lint code
       run: |
-        git submodule update --init --recursive go.mk
+        make go.mk
         PATH=$(go env GOPATH)/bin:$PATH make lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: git submodule update --init --recursive go.mk
+      - run: make go.mk
         shell: bash
 
       - name: Import GPG key

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ _test
 dist
 release
 bin
+/go.mk

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "go.mk"]
-	path = go.mk
-	url = https://github.com/exoscale/go.mk.git

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,36 @@
+GO_MK_REF := v1.0.0
+
+# make go.mk a dependency for all targets
+.EXTRA_PREREQS = go.mk
+
+ifndef MAKE_RESTARTS
+# This section will be processed the first time that make reads this file.
+
+# This causes make to re-read the Makefile and all included
+# makefiles after go.mk has been cloned.
+Makefile:
+	@touch Makefile
+endif
+
+.PHONY: go.mk
+.ONESHELL:
+go.mk:
+	@if [ ! -d "go.mk" ]; then
+		git clone https://github.com/exoscale/go.mk.git
+	fi
+	@cd go.mk
+	@if ! git show-ref --quiet --verify "refs/heads/${GO_MK_REF}"; then
+		git fetch
+	fi
+	@if ! git show-ref --quiet --verify "refs/tags/${GO_MK_REF}"; then
+		git fetch --tags
+	fi
+	git checkout --quiet ${GO_MK_REF}
+
 PROJECT_URL = https://github.com/exoscale/cert-manager-webhook-exoscale
+go.mk/init.mk:
 include go.mk/init.mk
+go.mk/public.mk:
 include go.mk/public.mk
 
 GO ?= $(shell which go)


### PR DESCRIPTION
## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Integration testing

## Testing
```shell
❯ make build
Cloning into 'go.mk'...
remote: Enumerating objects: 311, done.
remote: Counting objects: 100% (197/197), done.
remote: Compressing objects: 100% (95/95), done.
remote: Total 311 (delta 132), reused 138 (delta 93), pack-reused 114
Receiving objects: 100% (311/311), 62.32 KiB | 569.00 KiB/s, done.
Resolving deltas: 100% (175/175), done.
mkdir -p '/home/sauterp/src/github.com/exoscale/cert-manager-webhook-exoscale/bin'
'/home/sauterp/bin/go' build \
   \
  -ldflags "-X main.commit=89dea1d -X main.branch=philippsauter/sc-88913/go-mk-provide-alternative-to-submodule-approach -X main.buildDate=2024-02-23T10:04:56+0000 -X main.version=dev " \
   \
  -o '/home/sauterp/src/github.com/exoscale/cert-manager-webhook-exoscale/bin/' \
  '.'

❯ make docker-build
docker build \
	-t "exoscale/cert-manager-webhook-exoscale" \
	--build-arg VERSION="dev" \
	--build-arg VCS_REF="89dea1d" \
	--build-arg BUILD_DATE="2024-02-23T10:02:40Z" \
	.
docker tag "exoscale/cert-manager-webhook-exoscale":latest "exoscale/cert-manager-webhook-exoscale":dev
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/

Sending build context to Docker daemon  175.1MB
Step 1/17 : FROM golang:1.20-alpine AS build_deps
 ---> e9f54d6722ab
Step 2/17 : RUN apk add --no-cache git
 ---> Running in 115f060e652f
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/APKINDEX.tar.gz
(1/8) Installing brotli-libs (1.0.9-r14)
(2/8) Installing libunistring (1.1-r1)
(3/8) Installing libidn2 (2.3.4-r1)
(4/8) Installing nghttp2-libs (1.57.0-r0)
(5/8) Installing libcurl (8.5.0-r0)
(6/8) Installing libexpat (2.6.0-r0)
(7/8) Installing pcre2 (10.42-r1)
(8/8) Installing git (2.40.1-r0)
Executing busybox-1.36.0-r9.trigger
OK: 18 MiB in 24 packages
Removing intermediate container 115f060e652f
 ---> 53503c1ea072
Step 3/17 : WORKDIR /workspace
 ---> Running in a46e141ccf3a
Removing intermediate container a46e141ccf3a
 ---> 3594ca21cea4
Step 4/17 : COPY go.mod .
 ---> 30884757ba36
Step 5/17 : COPY go.sum .
 ---> 176f2b71de5c
Step 6/17 : RUN go mod download
 ---> Running in 89d6e2d25a52
Removing intermediate container 89d6e2d25a52
 ---> 2e47e9a8c4e8
Step 7/17 : FROM build_deps AS build
 ---> 2e47e9a8c4e8
Step 8/17 : COPY . .
 ---> 86ed83b43bd9
Step 9/17 : RUN CGO_ENABLED=0 go build -o webhook -ldflags '-w -extldflags "-static"' .
 ---> Running in 0944d2116ff4
Removing intermediate container 0944d2116ff4
 ---> 1e8f13eac301
Step 10/17 : FROM alpine:3.18
 ---> 8ca4688f4f35
Step 11/17 : RUN apk add --no-cache ca-certificates
 ---> Running in de0c9a708a76
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/APKINDEX.tar.gz
(1/1) Installing ca-certificates (20230506-r0)
Executing busybox-1.36.1-r2.trigger
Executing ca-certificates-20230506-r0.trigger
OK: 8 MiB in 16 packages
Removing intermediate container de0c9a708a76
 ---> 407fa959bc50
Step 12/17 : COPY --from=build /workspace/webhook /usr/local/bin/webhook
 ---> 93cccb710142
Step 13/17 : ARG VERSION
 ---> Running in dc0fd7507278
Removing intermediate container dc0fd7507278
 ---> c994f97bdfa8
Step 14/17 : ARG VCS_REF
 ---> Running in 66d380993df7
Removing intermediate container 66d380993df7
 ---> 43608604f48d
Step 15/17 : ARG BUILD_DATE
 ---> Running in e299f59fa9e5
Removing intermediate container e299f59fa9e5
 ---> 3247ef77c021
Step 16/17 : LABEL org.label-schema.build-date=${BUILD_DATE}       org.label-schema.vcs-ref=${VCS_REF}       org.label-schema.vcs-url="https://github.com/exoscale/cert-manager-webhook-exoscale"       org.label-schema.version=${VERSION}       org.label-schema.name="cert-manager-webhook-exoscale"       org.label-schema.vendor="Exoscale"       org.label-schema.description="Cert-manager Webhook for Exoscale"       org.label-schema.schema-version="1.0"
 ---> Running in bf462e963ed9
Removing intermediate container bf462e963ed9
 ---> a303f84e1888
Step 17/17 : ENTRYPOINT ["webhook"]
 ---> Running in f0f55d7de064
Removing intermediate container f0f55d7de064
 ---> 669f34d8e9f8
Successfully built 669f34d8e9f8
Successfully tagged exoscale/cert-manager-webhook-exoscale:latest
```
