### PR TITLE
go.mk: lint with staticcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - go.mk: remove submodule and initialize through make #15 
+- go.mk: lint with staticcheck #17 
 
 ## 0.3.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO_MK_REF := v1.0.0
+GO_MK_REF := v2.0.0
 
 # make go.mk a dependency for all targets
 .EXTRA_PREREQS = go.mk


### PR DESCRIPTION
# Description

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Integration testing

## Testing
```shell
❯ make lint
'/home/sauterp/bin/go' install honnef.co/go/tools/cmd/staticcheck@2023.1.7
'/home/sauterp/go/bin/staticcheck' \
   \
  ./...
```
