### PR TITLE
feat: match image tag with chart version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ OS ?= $(shell $(GO) env GOOS)
 GOARCH ?= $(shell $(GO) env GOARCH)
 
 IMAGE_NAME := "exoscale/cert-manager-webhook-exoscale"
-IMAGE_TAG := "latest"
 
 OUT := $(shell pwd)/_out
 

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ rendered-manifest.yaml:
 	helm template \
 	    exoscale-webhook \
         --set image.repository=$(IMAGE_NAME) \
-        --set image.tag="latest" \
         --namespace cert-manager \
         ${DEPLOY_DIR} > "$(OUT)/rendered-manifest.yaml"
 	cp "${OUT}/rendered-manifest.yaml" "${DEPLOY_DIR}-kustomize/deploy.yaml"

--- a/deploy/exoscale-webhook-kustomize/deploy.yaml
+++ b/deploy/exoscale-webhook-kustomize/deploy.yaml
@@ -186,7 +186,7 @@ spec:
       serviceAccountName: cert-manager-webhook-exoscale
       containers:
         - name: cert-manager-webhook-exoscale-chart
-          image: "exoscale/cert-manager-webhook-exoscale:latest"
+          image: "exoscale/cert-manager-webhook-exoscale:0.3.4"
           imagePullPolicy: IfNotPresent
           args:
             - --tls-cert-file=/tls/tls.crt

--- a/deploy/exoscale-webhook/values.yaml
+++ b/deploy/exoscale-webhook/values.yaml
@@ -6,7 +6,7 @@ certManager:
 
 image:
   repository: exoscale/cert-manager-webhook-exoscale
-  tag: latest
+  tag: 0.3.4
   pullPolicy: IfNotPresent
 
 nameOverride: "exoscale-webhook"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/exoscale/cert-manager-webhook-exoscale
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/cert-manager/cert-manager v1.19.4


### PR DESCRIPTION
# Description
For multiple reasons it is not recommended to use the latest tag. 
Therefore it would be nice if the the default tag in the values.yaml matches the version of the helm chart per default.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Integration testing

## Testing

<!--
Describe the tests you did
-->
